### PR TITLE
[flutter_local_notifications] feat: Added EveryThirtyDays interval.

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -800,6 +800,9 @@ public class FlutterLocalNotificationsPlugin
       case Weekly:
         repeatInterval = 60000 * 60 * 24 * 7;
         break;
+      case EveryThirtyDays:
+        repeatInterval = 60000 * 60 * 24 * 30;
+        break;
       default:
         break;
     }
@@ -1327,6 +1330,11 @@ public class FlutterLocalNotificationsPlugin
         == ScheduledNotificationRepeatFrequency.Weekly) {
       LocalDateTime localDateTime =
           LocalDateTime.parse(notificationDetails.scheduledDateTime).plusWeeks(1);
+      return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime);
+    } else if (notificationDetails.scheduledNotificationRepeatFrequency
+        == ScheduledNotificationRepeatFrequency.EveryThirtyDays) {
+      LocalDateTime localDateTime =
+          LocalDateTime.parse(notificationDetails.scheduledDateTime).plusDays(30);
       return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime);
     }
     return null;

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/RepeatInterval.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/RepeatInterval.java
@@ -7,5 +7,6 @@ public enum RepeatInterval {
   EveryMinute,
   Hourly,
   Daily,
-  Weekly
+  Weekly,
+  EveryThirtyDays
 }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/ScheduledNotificationRepeatFrequency.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/ScheduledNotificationRepeatFrequency.java
@@ -5,5 +5,6 @@ import androidx.annotation.Keep;
 @Keep
 public enum ScheduledNotificationRepeatFrequency {
   Daily,
-  Weekly
+  Weekly,
+  EveryThirtyDays
 }

--- a/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
@@ -113,7 +113,8 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
   EveryMinute,
   Hourly,
   Daily,
-  Weekly
+  Weekly,
+  EveryThirtyDays
 };
 
 typedef NS_ENUM(NSInteger, DateTimeComponents) {
@@ -834,6 +835,10 @@ static FlutterError *getFlutterError(NSError *error) {
   case Weekly:
     return [UNTimeIntervalNotificationTrigger
         triggerWithTimeInterval:60 * 60 * 24 * 7
+                        repeats:YES];
+  case EveryThirtyDays:
+    return [UNTimeIntervalNotificationTrigger
+        triggerWithTimeInterval:60 * 60 * 24 * 30
                         repeats:YES];
   }
   return nil;

--- a/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
@@ -64,6 +64,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
     enum ScheduledNotificationRepeatFrequency: Int {
         case daily
         case weekly
+        case everyThirtyDays
     }
 
     enum DateTimeComponents: Int {
@@ -78,6 +79,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         case hourly
         case daily
         case weekly
+        case everyThirtyDays
     }
 
     var channel: FlutterMethodChannel
@@ -524,6 +526,9 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                 return UNTimeIntervalNotificationTrigger.init(timeInterval: 60 * 60 * 24, repeats: true)
             case .weekly:
                 return UNTimeIntervalNotificationTrigger.init(timeInterval: 60 * 60 * 24 * 7, repeats: true)
+            }
+            case .everyThirtyDays:
+                return UNTimeIntervalNotificationTrigger.init(timeInterval: 60 * 60 * 24 * 30, repeats: true)
             }
         } else {
             let repeatIntervalSeconds = repeatIntervalMilliseconds! / 1000

--- a/flutter_local_notifications_platform_interface/lib/src/types.dart
+++ b/flutter_local_notifications_platform_interface/lib/src/types.dart
@@ -10,14 +10,21 @@ enum RepeatInterval {
   daily,
 
   /// Weekly interval.
-  weekly
+  weekly,
+
+  /// An interval for every 30 days.
+  everyThirtyDays,
 }
 
 /// Details of a pending notification that has not been delivered.
 class PendingNotificationRequest {
   /// Constructs an instance of [PendingNotificationRequest].
   const PendingNotificationRequest(
-      this.id, this.title, this.body, this.payload);
+    this.id,
+    this.title,
+    this.body,
+    this.payload,
+  );
 
   /// The notification's id.
   final int id;


### PR DESCRIPTION
Added a thirty day interval (`EveryThirtyDays`), for times when programmatically pre-scheduling multiple thirty day-spaced notifications is not possible, nor is `matchDateTimeComponents` precise enough due to the variance in month lengths across the calendar, causing misfires or even skips for monthly recurring scheduled notifications in months with more than 28 calendar days.